### PR TITLE
Exit Logic Modified

### DIFF
--- a/Load Master/src/com/pekinsoft/loadmaster/view/LoadMaster.java
+++ b/Load Master/src/com/pekinsoft/loadmaster/view/LoadMaster.java
@@ -507,16 +507,12 @@ public class LoadMaster extends javax.swing.JFrame {
         dlg.setVisible(true);
     }
     
-    private void doClose() {
-        String msg = "Exit Load Master?";
-        int response = MessageBox.askQuestion(msg, "Confirm Close", false);
-        
-        if ( response == MessageBox.YES_OPTION ) {
-            Starter.props.setPropertyAsInt("windows.main.state", 
-                    getExtendedState());
+    private void doClose() {Starter.props.setPropertyAsInt("windows.main.tb", 
+                tbSplit.getDividerLocation());
+        Starter.props.setPropertyAsInt("windows.main.lr", 
+                lrSplit.getDividerLocation());
 
-        Starter.props.setPropertyAsInt("windows.main.tb", tbSplit.getDividerLocation());
-        Starter.props.setPropertyAsInt("windows.main.lr", lrSplit.getDividerLocation());
+        Starter.props.setPropertyAsInt("windows.main.state", getExtendedState());
         
         if ( getExtendedState() != JFrame.MAXIMIZED_BOTH ) {
             Starter.props.setPropertyAsInt("windows.main.top", getLocation().y);
@@ -524,8 +520,38 @@ public class LoadMaster extends javax.swing.JFrame {
             Starter.props.setPropertyAsInt("windows.main.height", getSize().height);
             Starter.props.setPropertyAsInt("windows.main.width", getSize().width);
         }
-            Starter.exit(SysExits.EX_OK);
+                
+        if ( Boolean.parseBoolean(Starter.props.getProperty(
+                "acct.batch", "false")) ) {
+            int unprocessed = Starter.props.getPropertyAsInt("acct.batch.count", 
+                    "0");
+            if ( unprocessed > 0 ) {
+                confirmExit(unprocessed);
+            } else {
+                exit(SysExits.EX_OK);
+            }
+        
+        } else {
+            exit(SysExits.EX_OK);
         }
+    }
+    
+    private void confirmExit(int count) {
+        int response = MessageBox.askQuestion("There are " + count + 
+                " unprocessed transactions.\n\nWould you like to process these "
+                        + "before exiting", "Unposted Transactions", true);
+        
+        if ( response == MessageBox.YES_OPTION ) {
+            // Process batch to General Ledger.
+        } else if ( response == MessageBox.NO_OPTION ) {
+            exit(SysExits.EX_OK);
+        } // if the response is MessageBox.CANCEL_OPTION, we do nothing to let
+          //+ the application continue. Maybe the user is going to process the
+          //+ batch manually.
+    }
+    
+    private void exit(SysExits status) {
+        Starter.exit(status);
     }
     
     private void doCloseLoad() {

--- a/Load Master/src/com/pekinsoft/loadmaster/view/LoadMaster.java
+++ b/Load Master/src/com/pekinsoft/loadmaster/view/LoadMaster.java
@@ -522,7 +522,7 @@ public class LoadMaster extends javax.swing.JFrame {
         }
                 
         if ( Boolean.parseBoolean(Starter.props.getProperty(
-                "acct.batch", "false")) ) {
+                "acct.batch", "false")) & Starter.batch != null) {
             int unprocessed = Starter.batch.getRecordCount();
             if ( unprocessed > 0 ) {
                 confirmExit(unprocessed);

--- a/Load Master/src/com/pekinsoft/loadmaster/view/LoadMaster.java
+++ b/Load Master/src/com/pekinsoft/loadmaster/view/LoadMaster.java
@@ -523,8 +523,7 @@ public class LoadMaster extends javax.swing.JFrame {
                 
         if ( Boolean.parseBoolean(Starter.props.getProperty(
                 "acct.batch", "false")) ) {
-            int unprocessed = Starter.props.getPropertyAsInt("acct.batch.count", 
-                    "0");
+            int unprocessed = Starter.batch.getRecordCount();
             if ( unprocessed > 0 ) {
                 confirmExit(unprocessed);
             } else {

--- a/Load Master/test/com/pekinsoft/loadmaster/tests/MainWindowTest.java
+++ b/Load Master/test/com/pekinsoft/loadmaster/tests/MainWindowTest.java
@@ -67,15 +67,14 @@ public class MainWindowTest {
 
     @AfterClass
     public static void tearDownClass() {
-        mainWindowOperator.callExit();
-        Tools.pushButtonInDialog("Confirm Close", "No");
+//        mainWindowOperator.callExit();
+//        Tools.pushButtonInDialog("Confirm Close", "No");
         PNGEncoder.captureScreen("ApplicationExiting.png", PNGEncoder.COLOR_MODE);
     }
 
     @Test
     public void testBookNewLoadWizard() {
         mainWindowOperator.callBookNewLoad();
-        new EventTool().waitNoEvent(1000);
 
         BookNewLoadWizardOperator bookNewLoadWizardOperator = new BookNewLoadWizardOperator();
         assertEquals(bookNewLoadWizardOperator.getPageName(), "Load Information");


### PR DESCRIPTION
I have modified the logic behind exiting LoadMaster. Now, instead of always displaying a confirmation dialog to exit, the confirmation will only be displayed under two conditions:

1. The `Starter.props.getProperty("acct.batch")` setting equals `true`
2. The `Starter.props.getProperty("acct.batch.count")` setting is greater than 0

If those two conditions are met, then a confirmation dialog will be displayed to the user regarding posting the unprocessed batch of transactions. This modification is in accordance with the [Exit Flow Diagram Wiki Page](https://github.com/PekinSOFT-Systems/LoadMaster/wiki/Exit-Flow-Diagram).

With this update in place, @jkovalsky can get his exit testing fully functional and can ***finally*** test his tests. My apologies for the delay in getting this modification completed.

-SC
Signed-off-by:Sean Carrick <sean at pekinsoft dot com>